### PR TITLE
Merge upstream changes to Caddyfile and index.html; redirect .md links to source

### DIFF
--- a/media/Caddyfile
+++ b/media/Caddyfile
@@ -2,22 +2,55 @@
 # 2. overwrite /etc/caddy/Caddyfile with this file
 # 3. sudo systemctl restart caddy
 
-#http://blog.gpt4.org {
 :80 {
     root * /home/shawn/website
     
-    file_server
-
-    @page not path /media/*
-    templates @page
-    rewrite @page /templates/index.html
-
     encode gzip
 
-    handle_errors {
-        rewrite * /templates/error.html
+    file_server
+    templates
 
+    @media {
+        path /favicon.ico
+        path /media/*
+    }
+    @markdown {
+        path_regexp \.md$
+    }
+    @markdown_exists {
+        file {path}.md
+    }
+
+    handle @media {
+        file_server
+    }
+    handle @markdown {
+        rewrite * /templates/index.html
+    }
+    handle @markdown_exists {
+        map {path} {caddy_markdown_site.append_to_path} {
+            default extension
+        }
+        rewrite * /templates/index.html
+    }
+
+    handle_errors {
         file_server
         templates
+
+        @markdown_index_exists {
+            file {path}/index.md
+            expression `{http.error.status_code} == 404`
+        }
+
+        handle @markdown_index_exists {
+            map {path} {caddy_markdown_site.append_to_path} {
+                default index
+            }
+            rewrite @markdown_index_exists /templates/index.html
+        }
+        handle {
+            rewrite * /templates/error.html
+        }
     }
 }

--- a/media/Caddyfile
+++ b/media/Caddyfile
@@ -18,6 +18,7 @@
         path /media/*
     }
     @markdown {
+        file
         path_regexp \.md$
     }
     @markdown_exists {

--- a/media/Caddyfile
+++ b/media/Caddyfile
@@ -28,7 +28,7 @@
         file_server
     }
     handle @markdown {
-        rewrite * /templates/index.html
+        redir * https://github.com/shawwn/website/blob/master{path}
     }
     handle @markdown_exists {
         map {path} {caddy_markdown_site.append_to_path} {

--- a/media/Caddyfile
+++ b/media/Caddyfile
@@ -1,6 +1,9 @@
+# Based on https://github.com/dbohdan/caddy-markdown-site
+
 # 1. install caddy_2.4.3_linux_amd64.deb from https://github.com/caddyserver/caddy/releases/tag/v2.4.3
 # 2. overwrite /etc/caddy/Caddyfile with this file
 # 3. sudo systemctl restart caddy
+# 4. make sure /home/shawn/website is readable by anyone
 
 :80 {
     root * /home/shawn/website

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,9 +1,14 @@
 <!DOCTYPE html>
 
-{{ $pathParts := splitList "/" .OriginalReq.URL.Path }}
-{{ $markdownFilePath := printf "%s.md" (default "index" (slice $pathParts 1 | join "/")) }}
-{{ $markdownFile := (include $markdownFilePath | splitFrontMatter) }}
-{{ $title := default .OriginalReq.URL.Path $markdownFile.Meta.title }}
+{{ $path := .OriginalReq.URL.Path }}
+{{ $append := placeholder "caddy_markdown_site.append_to_path" }}
+{{ if eq $append "extension" }}
+    {{ $path = printf "%s.md" $path }}
+{{ else if eq $append "index" }}
+    {{ $path = printf "%s/index.md" $path }}
+{{ end }}
+{{ $markdownFile := (include $path | splitFrontMatter) }}
+{{ $title := default $path $markdownFile.Meta.title }}
 
 <html>
 <head>

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,9 +20,15 @@
 </head>
 <body>
     {{ include "/templates/header.html" }}
+
     <main>
         <article>{{ markdown $markdownFile.Body }}</article>
     </main>
+
+    <footer>
+        <a href="{{ $path | clean }}">Page source code</a>.
+    </footer>
+
     {{ include "/templates/footer.html" }}
 </body>
 </html>


### PR DESCRIPTION
https://github.com/dbohdan/caddy-markdown-site/commit/8ed96715496ad5fd5a386a1e77e7be0522ce2967

This improves several things:

* Both example.com/path/foo and example.com/path/foo.md returns the page;
* Indices work in subdirs;
* You can serve plain HTML pages, too;
* Missing files return error 404, not 500;
* You can have a favicon.ico.

You will need to copy `website/media/Caddyfile` to `/etc/caddy/Caddyfile` and restart the server.